### PR TITLE
MunkiRequires, PPD file checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pkginfo
+
+SAS_Template.csv

--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -72,6 +72,7 @@ sys.exit(1)</string>
 	<string>#!/usr/bin/python
 import subprocess
 import sys
+import os.path
 
 # If specified PPD not found, fail.
 if not os.path.exists( "DRIVER" ):

--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -47,7 +47,7 @@ for option in lpoptLongOut.splitlines():
                 actualOptionValue = opt.replace('*', '')
                 break
         if optionName == myOption:
-            if not printerOptions[myOption] == actualOptionValue:
+            if not printerOptions[myOption].lower() == actualOptionValue.lower():
                 print "Found mismatch: %s is '%s', should be '%s'" % (myOption, printerOptions[myOption], actualOptionValue)
                 sys.exit(0)
 

--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -34,8 +34,8 @@ cmd = ['/usr/bin/lpoptions', '-p', 'PRINTERNAME']
 proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (lpoptOut, lpoptErr) = proc.communicate()
 
-#Note: lpoptions -p printername will never fail. If PRINTERNAME does not exist, it 
-#will still exit 0, but just produce no output.  
+#Note: lpoptions -p printername will never fail. If PRINTERNAME does not exist, it
+#will still exit 0, but just produce no output.
 #Thanks, cups, I was having a good day until now.
 
 for option in lpoptLongOut.splitlines():
@@ -51,10 +51,10 @@ for option in lpoptLongOut.splitlines():
                 print "Found mismatch: %s is '%s', should be '%s'" % (myOption, printerOptions[myOption], actualOptionValue)
                 sys.exit(0)
 
-optionDict = dict()                
+optionDict = dict()
 for builtOption in shlex.split(lpoptOut):
     optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
-    
+
 comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION", "printer-make-and-model":"DRIVER" }
 for keyName in comparisonDict.keys():
     if not comparisonDict[keyName] == optionDict[keyName]:
@@ -72,6 +72,13 @@ sys.exit(1)</string>
 	<string>#!/usr/bin/python
 import subprocess
 import sys
+
+# If specified PPD not found, fail.
+if not os.path.exists( "DRIVER" ):
+	print "PPD DRIVER not found."
+	sys.exit(1)
+
+
 
 # Populate these options if you want to set specific options for the printer. E.g. duplexing installed, etc.
 printerOptions = { OPTIONS }
@@ -101,7 +108,7 @@ proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 if lpadminErr:
     print "Error: %s" % lpadminErr
     sys.exit(1)
-print "Results: %s" % lpadminOut    
+print "Results: %s" % lpadminOut
 sys.exit(0)</string>
 	<key>unattended_install</key>
 	<true/>

--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -55,7 +55,7 @@ optionDict = dict()
 for builtOption in shlex.split(lpoptOut):
     optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
 
-comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION", "printer-make-and-model":"DRIVER" }
+comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION" }
 for keyName in comparisonDict.keys():
     if not comparisonDict[keyName] == optionDict[keyName]:
         print "Settings mismatch: %s is '%s', should be '%s'" % (keyName, optionDict[keyName], comparisonDict[keyName])

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The CSV file's columns should be pretty self-explanatory:
 * Display name: The visual name that shows up in the Printers & Scanners pane of the System Preferences, and in the print dialogue boxes.  Also used in the Munki pkginfo.
 * Address: The IP or DNS address of the printer. The template uses the form: `lpr://ADDRESS`.  Change to another protocol in the template if necessary.
 * Driver: Name of the driver file in /Library/Printers/PPDs/Contents/Resources/.
-* Description: Used only in the Munki pkginfo. 
+* Description: Used only in the Munki pkginfo.
+* MunkiRequires: List of munki packages to be listed as requirements in pkginfo
 * Options: Any printer options that should be specified. These **must** be space-delimited key=value pairs, such as "HPOptionDuplexer=True OutputMode=normal".  **Do not use commas to separate the options, because this is a comma-separated values file.**
 
 The CSV file is not sanity-checked for invalid entries or blank fields, so double check your file and test your pkginfos thoroughly.
@@ -90,7 +91,7 @@ As in the above CSV section, the arguments are all the same:
 * `--location`: The "location" of the printer. If not provided, this will default to the value of `--printername`.
 * `--displayname`: The visual name that shows up in the Printers & Scanners pane of the System Preferences, and in the print dialogue boxes.  Also used in the Munki pkginfo.  If not provided, this will default to the value of `--printername`.
 * `--desc`: Used only in the Munki pkginfo. If not provided, will default to an empty string ("").
-* `--options`: Any number of printer options that should be specified. These should be space-delimited key=value pairs, such as "HPOptionDuplexer=True OutputMode=normal". 
+* `--options`: Any number of printer options that should be specified. These should be space-delimited key=value pairs, such as "HPOptionDuplexer=True OutputMode=normal".
 * `--version`: The version number of the Munki pkginfo. Defaults to "1.0".
 
 ### Figuring out options:
@@ -169,7 +170,7 @@ cmd = ['/usr/bin/lpoptions', '-p', 'MyPrinterQueue']
 proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (lpoptOut, lpoptErr) = proc.communicate()
 
-#Note: lpoptions -p printername will never fail. If MyPrinterQueue does not exist, it 
+#Note: lpoptions -p printername will never fail. If MyPrinterQueue does not exist, it
 #will still exit 0, but just produce no output.  
 #Thanks, cups, I was having a good day until now.
 
@@ -189,7 +190,7 @@ for option in lpoptLongOut.splitlines():
 optionDict = dict()                
 for builtOption in shlex.split(lpoptOut):
     optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
-    
+
 comparisonDict = { "device-uri":"lpd://10.0.0.1", "printer-info":"My Printer Queue", "printer-location":"Tech Office", "printer-make-and-model":"HP officejet 5500 series.ppd" }
 for keyName in comparisonDict.keys():
     if not comparisonDict[keyName] == optionDict[keyName]:

--- a/Template.csv
+++ b/Template.csv
@@ -1,2 +1,2 @@
 Printer Name,Location,Display Name,Address,Driver,Description,Options
-MyPrinterQueue,Tech Office,My Printer Queue,10.0.0.1,HP officejet 5500 series.ppd.gz,Black and white printer in Tech Office,HPOptionDuplexer=True OutputMode=normal
+MyPrinterQueue,Tech Office,My Printer Queue,10.0.0.1,HP officejet 5500 series.ppd.gz,Black and white printer in Tech Office,HewletPackardPrinterDrivers OtherMunkiPackage,HPOptionDuplexer=True OutputMode=normal

--- a/Template.csv
+++ b/Template.csv
@@ -1,2 +1,2 @@
-Printer Name,Location,Display Name,Address,Driver,Description,Options
+Printer Name,Location,Display Name,Address,Driver,Description,Requirements,Options
 MyPrinterQueue,Tech Office,My Printer Queue,10.0.0.1,HP officejet 5500 series.ppd.gz,Black and white printer in Tech Office,HewletPackardPrinterDrivers OtherMunkiPackage,HPOptionDuplexer=True OutputMode=normal

--- a/print_generator.py
+++ b/print_generator.py
@@ -44,6 +44,7 @@ if args.csv:
             requirementList = ''
             if row[6] != "":
                 requirementList = row[6].split(" ")
+                newPlist['requires'] = requirementList
             theOptionString = ''
             if row[7] != "":
                 theOptionString = getOptionsString(row[7].split(" "))

--- a/print_generator.py
+++ b/print_generator.py
@@ -26,7 +26,7 @@ parser.add_argument('--csv', help='Path to CSV file containing printer info. If 
 args = parser.parse_args()
 
 
-f = open('AddPrinter-Template.plist', 'rb')
+f = open('Printer-Template.plist', 'rb')
 templatePlist = readPlist(f)
 f.close()
 
@@ -37,16 +37,20 @@ if args.csv:
         next(reader, None) # skip the header row
         for row in reader:
             newPlist = dict(templatePlist)
-            # each row contains 7 elements:
-            # Printer name, location, display name, address, driver, description, options
+            # each row contains 8 elements:
+            # Printer name, location, display name, address, driver, description, requirements, options
+            # requirements is space separated list of munki packages that this printer requiers
             # options in the form of "Option=Value Option2=Value Option3=Value"
-            theOptionString = ''
+            requirementList = ''
             if row[6] != "":
-                theOptionString = getOptionsString(row[6].split(" "))
+                requirementList = row[6].split(" ")
+            theOptionString = ''
+            if row[7] != "":
+                theOptionString = getOptionsString(row[7].split(" "))
             # First, change the plist keys in the pkginfo itself
-            newPlist['display_name'] = row[2]
+            newPlist['display_name'] = "Printer - " + str(row[2])
             newPlist['description'] = row[5]
-            newPlist['name'] = "AddPrinter_" + str(row[0]) # set to printer name
+            newPlist['name'] = "AddPrinter_" + str(row[0]).replace('-', '_') # set to printer name, don't use - in names
             # Default choice for versions for CSV is 1.0.
             newPlist['version'] = "1.0"
             # Check for a protocol listed in the address
@@ -80,7 +84,7 @@ if args.csv:
             # Now change the one variable in the uninstall_script
             newPlist['uninstall_script'] = newPlist['uninstall_script'].replace("PRINTERNAME", row[0])
             # Write out the file
-            newFileName = "AddPrinter-" + row[0] + "-1.0.pkginfo"
+            newFileName = "AddPrinter-" + row[0] + ".pkginfo"
             f = open(newFileName, 'wb')
             writePlist(newPlist, f)
             f.close()
@@ -97,12 +101,12 @@ else:
         print >> sys.stderr, (os.path.basename(sys.argv[0]) + ': error: argument --address is required')
         parser.print_usage()
         sys.exit(1)
-    
+
     if re.search(r"[\s#/]", args.printername):
         # printernames can't contain spaces, tabs, # or /.  See lpadmin manpage for details.
         print >> sys.stderr, ("ERROR: Printernames can't contain spaces, tabs, # or /.")
         sys.exit(1)
-    
+
     if args.desc:
         description = args.desc
     else:
@@ -112,7 +116,7 @@ else:
         displayName = args.displayname
     else:
         displayName = str(args.printername)
-        
+
     if args.location:
         location = args.location
     else:
@@ -134,18 +138,18 @@ else:
     else:
         # Assume only a relative filename
         driver = os.path.join('/Library/Printers/PPDs/Contents/Resources', args.driver)
-        
+
     if '://' in args.address:
         # Assume the user passed in a full address and protocol
         address = args.address
     else:
         # Assume the user wants to use the default, lpd://
         address = 'lpd://' + args.address
-    
+
     newPlist = dict(templatePlist)
    # root pkginfo variable replacement
     newPlist['description'] = description
-    newPlist['display_name'] = displayName
+    newPlist['display_name'] = "Printer - " + displayName
     newPlist['name'] = "AddPrinter_" + displayName.replace(" ", "")
     newPlist['version'] = version
     # installcheck_script variable replacement
@@ -154,14 +158,14 @@ else:
     newPlist['installcheck_script'] = newPlist['installcheck_script'].replace("DISPLAY_NAME", displayName)
     newPlist['installcheck_script'] = newPlist['installcheck_script'].replace("LOCATION", location.replace('"', ''))
     newPlist['installcheck_script'] = newPlist['installcheck_script'].replace("DRIVER", os.path.splitext(os.path.basename(driver))[0].replace('"', ''))
-    newPlist['installcheck_script'] = newPlist['installcheck_script'].replace("OPTIONS", optionsString)            
+    newPlist['installcheck_script'] = newPlist['installcheck_script'].replace("OPTIONS", optionsString)
     # postinstall_script variable replacement
     newPlist['postinstall_script'] = templatePlist['postinstall_script'].replace("PRINTERNAME", args.printername)
     newPlist['postinstall_script'] = newPlist['postinstall_script'].replace("ADDRESS", address)
     newPlist['postinstall_script'] = newPlist['postinstall_script'].replace("DISPLAY_NAME", displayName)
     newPlist['postinstall_script'] = newPlist['postinstall_script'].replace("LOCATION", location.replace('"', ''))
     newPlist['postinstall_script'] = newPlist['postinstall_script'].replace("DRIVER", driver.replace('"', ''))
-    newPlist['postinstall_script'] = newPlist['postinstall_script'].replace("OPTIONS", optionsString)            
+    newPlist['postinstall_script'] = newPlist['postinstall_script'].replace("OPTIONS", optionsString)
     # uninstall_script variable replacement
     newPlist['uninstall_script'] = templatePlist['uninstall_script'].replace("PRINTERNAME", args.printername)
 

--- a/print_generator.py
+++ b/print_generator.py
@@ -26,7 +26,7 @@ parser.add_argument('--csv', help='Path to CSV file containing printer info. If 
 args = parser.parse_args()
 
 
-f = open('Printer-Template.plist', 'rb')
+f = open('AddPrinter-Template.plist', 'rb')
 templatePlist = readPlist(f)
 f.close()
 

--- a/print_generator.py
+++ b/print_generator.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 import os
+import os.path
 from plistlib import readPlist, writePlist
 import csv
 import argparse

--- a/print_generator.py
+++ b/print_generator.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 import os
-import os.path
 from plistlib import readPlist, writePlist
 import csv
 import argparse


### PR DESCRIPTION
Additional column in Template CSV for required munki packages.  This is a space separated list of items that should be included under the "requires" key in pkginfo.  

Postinstall script now checks for existence of PPD file and fails if not found.  Prevents creation of "RAW" queues on OSX that are listed by CUPS but don't show in System Preferences.  

Removed install_check scan for "Printer Make and Model" since some PPDs list this as a different string that just the PPD name (ex. Kyocera).  This was causing the printer to reinstall every run.  
