### PR TITLE
Don't check printer-make-and-model

### DIFF
--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -55,7 +55,7 @@ optionDict = dict()
 for builtOption in shlex.split(lpoptOut):
     optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
     
-comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION", "printer-make-and-model":"DRIVER" }
+comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION" }
 for keyName in comparisonDict.keys():
     if not comparisonDict[keyName] == optionDict[keyName]:
         print "Settings mismatch: %s is '%s', should be '%s'" % (keyName, optionDict[keyName], comparisonDict[keyName])


### PR DESCRIPTION
Don't assume that printer-make-and-model matches the name of the driver. For example, our Konica Minolta bizhub C280 has a model of "KONICA MINOLTA C280 PS" while the driver is named "KONICAMINOLTAC280". Otherwise, munki will always try to install/update the printer as the two values don't match.
