### PR TITLE
Fixes index out of range bug in installcheck_script

### DIFF
--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -51,9 +51,12 @@ for option in lpoptLongOut.splitlines():
                 print "Found mismatch: %s is '%s', should be '%s'" % (myOption, printerOptions[myOption], actualOptionValue)
                 sys.exit(0)
 
-optionDict = dict()                
+optionDict = {}                
 for builtOption in shlex.split(lpoptOut):
-    optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
+    try:
+        optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
+    except:
+        optionDict[builtOption.split("=")[0]] = None
     
 comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION", "printer-make-and-model":"DRIVER" }
 for keyName in comparisonDict.keys():


### PR DESCRIPTION
When the `installcheck_script` is run, an exception is raised when the `builtOption.split("=")` list has no values:
```    Traceback (most recent call last):
      File "/tmp/munki-f0VjAH/installcheck_script", line 41, in <module>
        optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
    IndexError: list index out of range
```

Using a `try, except` flow control statement solves this issue by setting `optionDict[builtOption.split("=")[0]]` to `None` type when there is no value in the list for that option.