### PR TITLE
Fixes exception with --options and removes trailing comma in printerOptions dict.

### DIFF
--- a/print_generator.py
+++ b/print_generator.py
@@ -10,12 +10,12 @@ def getOptionsString(optionList):
     # optionList should be a list item
     optionsString = ''
     for option in optionList:
-        if optionList[-1]:
+        if option == optionList[-1]:
             optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1]))
         else:
             optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1])) + ', '
-
     return optionsString
+
 
 parser = argparse.ArgumentParser(description='Generate a Munki nopkg-style pkginfo for printer installation.')
 parser.add_argument('--printername', help='Name of printer queue. May not contain spaces, tabs, # or /. Required.')

--- a/print_generator.py
+++ b/print_generator.py
@@ -124,7 +124,8 @@ else:
         version = "1.0"
 
     if args.options:
-        optionsString = getOptionsString(args.options[0])
+        optionsString = str(args.options[0]).split(' ')
+        optionsString = getOptionsString(optionsString)
     else:
         optionsString = ''
 

--- a/print_generator.py
+++ b/print_generator.py
@@ -16,7 +16,6 @@ def getOptionsString(optionList):
             optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1])) + ', '
     return optionsString
 
-
 parser = argparse.ArgumentParser(description='Generate a Munki nopkg-style pkginfo for printer installation.')
 parser.add_argument('--printername', help='Name of printer queue. May not contain spaces, tabs, # or /. Required.')
 parser.add_argument('--driver', help='Name of driver file in /Library/Printers/PPDs/Contents/Resources/. Can be relative or full path. Required.')

--- a/print_generator.py
+++ b/print_generator.py
@@ -10,7 +10,11 @@ def getOptionsString(optionList):
     # optionList should be a list item
     optionsString = ''
     for option in optionList:
-        optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1])) + ', '
+        if optionList[-1]:
+            optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1]))
+        else:
+            optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1])) + ', '
+
     return optionsString
 
 parser = argparse.ArgumentParser(description='Generate a Munki nopkg-style pkginfo for printer installation.')


### PR DESCRIPTION
Fixes the `IndexError: list index out of range` exception when more than one option is passed to the `--options` flag:
```
[foo@example]:PrinterGenerator # ./print_generator.py --printername="MyPrinterQueue" --driver="HP officejet 5500 series.ppd.gz" --address="10.0.0.1" --location="Tech Office" --displayname="My Printer Queue" --desc="Black and white printer in Tech Office" --options "HPOptionDuplexer=True OutputMode=normal" --version=1.5
Traceback (most recent call last):
  File "./print_generator.py", line 127, in <module>
    optionsString = getOptionsString(args.options[0])
  File "./print_generator.py", line 13, in getOptionsString
    optionsString += "\"%s\":\"%s\"" % (str(option.split('=')[0]), str(option.split('=')[1])) + ', '
IndexError: list index out of range
```
This creates the correct `printerOptions = { "HPOptionDuplexer":"True", "OutputMode":"normal",  }` line in the generated `.pkginfo` file (although the last `,` in the dict may need removing.

Removes last comma in printerOptions dict:
There is a trailing `,` in the `printerOptions` dict that is inserted into the `pkginfo` file. This can cause issues with the install command.