### PR TITLE
Version option added for CSV pkginfo generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ The CSV file's columns should be pretty self-explanatory:
 * Display name: The visual name that shows up in the Printers & Scanners pane of the System Preferences, and in the print dialogue boxes.  Also used in the Munki pkginfo.
 * Address: The IP or DNS address of the printer. The template uses the form: `lpr://ADDRESS`.  Change to another protocol in the template if necessary.
 * Driver: Name of the driver file in /Library/Printers/PPDs/Contents/Resources/.
-* Description: Used only in the Munki pkginfo. 
+* Description: Used only in the Munki pkginfo.
 * Options: Any printer options that should be specified. These **must** be space-delimited key=value pairs, such as "HPOptionDuplexer=True OutputMode=normal".  **Do not use commas to separate the options, because this is a comma-separated values file.**
+* Version: Used only in the Munki pkginfo.
 
 The CSV file is not sanity-checked for invalid entries or blank fields, so double check your file and test your pkginfos thoroughly.
 

--- a/Template.csv
+++ b/Template.csv
@@ -1,2 +1,2 @@
-Printer Name,Location,Display Name,Address,Driver,Description,Options
-MyPrinterQueue,Tech Office,My Printer Queue,10.0.0.1,HP officejet 5500 series.ppd.gz,Black and white printer in Tech Office,HPOptionDuplexer=True OutputMode=normal
+Printer Name,Location,Display Name,Address,Driver,Description,Options,Version
+MyPrinterQueue,Tech Office,My Printer Queue,10.0.0.1,HP officejet 5500 series.ppd.gz,Black and white printer in Tech Office,HPOptionDuplexer=True OutputMode=normal,1.0

--- a/print_generator.py
+++ b/print_generator.py
@@ -40,8 +40,8 @@ if args.csv:
         next(reader, None) # skip the header row
         for row in reader:
             newPlist = dict(templatePlist)
-            # each row contains 7 elements:
-            # Printer name, location, display name, address, driver, description, options
+            # each row contains 8 elements:
+            # Printer name, location, display name, address, driver, description, options, version
             # options in the form of "Option=Value Option2=Value Option3=Value"
             theOptionString = ''
             if row[6] != "":
@@ -50,8 +50,14 @@ if args.csv:
             newPlist['display_name'] = row[2]
             newPlist['description'] = row[5]
             newPlist['name'] = "AddPrinter_" + str(row[0]) # set to printer name
-            # Default choice for versions for CSV is 1.0.
-            newPlist['version'] = "1.0"
+            # Check for a version number
+            if row[7] != "":
+                # Assume the user specified a version number
+                version = row[7]
+            else:
+                # Use the default version of 1.0
+                version = "1.0"
+            newPlist['version'] = version
             # Check for a protocol listed in the address
             if '://' in row[3]:
                 # Assume the user passed in a full address and protocol
@@ -83,7 +89,7 @@ if args.csv:
             # Now change the one variable in the uninstall_script
             newPlist['uninstall_script'] = newPlist['uninstall_script'].replace("PRINTERNAME", row[0])
             # Write out the file
-            newFileName = "AddPrinter-" + row[0] + "-1.0.pkginfo"
+            newFileName = "AddPrinter-" + row[0] + "-" + version + ".pkginfo"
             f = open(newFileName, 'wb')
             writePlist(newPlist, f)
             f.close()


### PR DESCRIPTION
This adds an optional additional column to the CSV file to allow manually specified version numbers for parity with the command line option. If no version is specified in the CSV the script defaults to 1.0.