### PR TITLE
Support for calling for different directory

### DIFF
--- a/print_generator.py
+++ b/print_generator.py
@@ -186,7 +186,7 @@ else:
     newPlist['uninstall_script'] = templatePlist['uninstall_script'].replace("PRINTERNAME", args.printername)
     # required packages
     if requires != "":
-        newPlist['requires'] = requires.split(' ')
+        newPlist['requires'] = re.split(r'(?<!\\)\w', requires)
 
     newFileName = "AddPrinter-" + str(args.printername) + "-%s.pkginfo" % str(version)
     f = open(newFileName, 'wb')

--- a/print_generator.py
+++ b/print_generator.py
@@ -30,7 +30,8 @@ parser.add_argument('--csv', help='Path to CSV file containing printer info. If 
 args = parser.parse_args()
 
 
-f = open('AddPrinter-Template.plist', 'rb')
+pwd = os.path.dirname(os.path.realpath(__file__))
+f = open(os.path.join(pwd, 'AddPrinter-Template.plist'), 'rb')
 templatePlist = readPlist(f)
 f.close()
 
@@ -186,7 +187,7 @@ else:
     newPlist['uninstall_script'] = templatePlist['uninstall_script'].replace("PRINTERNAME", args.printername)
     # required packages
     if requires != "":
-        newPlist['requires'] = re.split(r'(?<!\\)\w', requires)
+        newPlist['requires'] = [r.replace('\\', '') for r in re.split(r"(?<!\\)\s", requires)]
 
     newFileName = "AddPrinter-" + str(args.printername) + "-%s.pkginfo" % str(version)
     f = open(newFileName, 'wb')


### PR DESCRIPTION
Two very small tweaks I thought were useful.

1. Always look for the template in the same directory as the script is kept, instead of the working directory. This allows the script to be called from another location, e.g. a parent directory. Output files are still placed in the working directory.

2. Allow escaping spaces when specifying requirements. The printer driver we use has spaces in the name which couldn't be escaped before. Now "Requirement\ 1 Requirement2" will be interpreted as two requirements, "Requirement 1" and "Requirement2"

I don't think that either of these should interfere with any existing workflows.