### PR TITLE
Handle missing keys in optionDict

### DIFF
--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -61,7 +61,7 @@ for builtOption in shlex.split(lpoptOut):
 comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION" }
 for keyName in comparisonDict.keys():
     comparisonDict[keyName] = None if comparisonDict[keyName].strip() == "" else comparisonDict[keyName]
-    optionDict[keyName] = None if optionDict[keyName].strip() == "" else optionDict[keyName]
+    optionDict[keyName] = None if keyName not in optionDict or optionDict[keyName].strip() == "" else optionDict[keyName]
     if not comparisonDict[keyName] == optionDict[keyName]:
         print "Settings mismatch: %s is '%s', should be '%s'" % (keyName, optionDict[keyName], comparisonDict[keyName])
         sys.exit(0)


### PR DESCRIPTION
This can occur when CUPS has a PPD file for the printer being checked in its ppd/ folder, but the printer is not defined in the printers.conf file. CUPS will supply output for the lpoptions -p \<PRINTERNAME\> -l command, but nothing for lpoptions -p \<PRINTERNAME\>.