### PR TITLE
Update script for Python 3 compatibility

### DIFF
--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -27,15 +27,15 @@ proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 # lpoptions -p printername -l will still exit 0 even if printername does not exist
 # but it will print to stderr
 if lpoptErr:
-    print lpoptErr
+    print(lpoptErr)
     sys.exit(0)
 
 cmd = ['/usr/bin/lpoptions', '-p', 'PRINTERNAME']
 proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (lpoptOut, lpoptErr) = proc.communicate()
 
-#Note: lpoptions -p printername will never fail. If PRINTERNAME does not exist, it 
-#will still exit 0, but just produce no output.  
+#Note: lpoptions -p printername will never fail. If PRINTERNAME does not exist, it
+#will still exit 0, but just produce no output.
 #Thanks, cups, I was having a good day until now.
 
 for option in lpoptLongOut.splitlines():
@@ -48,22 +48,22 @@ for option in lpoptLongOut.splitlines():
                 break
         if optionName == myOption:
             if not printerOptions[myOption].lower() == actualOptionValue.lower():
-                print "Found mismatch: %s is '%s', should be '%s'" % (myOption, printerOptions[myOption], actualOptionValue)
+                print("Found mismatch: %s is '%s', should be '%s'" % (myOption, printerOptions[myOption], actualOptionValue))
                 sys.exit(0)
 
-optionDict = {}                
+optionDict = {}
 for builtOption in shlex.split(lpoptOut):
     try:
         optionDict[builtOption.split("=")[0]] = builtOption.split("=")[1]
     except:
         optionDict[builtOption.split("=")[0]] = None
-    
+
 comparisonDict = { "device-uri":"ADDRESS", "printer-info":"DISPLAY_NAME", "printer-location":"LOCATION" }
 for keyName in comparisonDict.keys():
     comparisonDict[keyName] = None if comparisonDict[keyName].strip() == "" else comparisonDict[keyName]
     optionDict[keyName] = None if keyName not in optionDict or optionDict[keyName].strip() == "" else optionDict[keyName]
     if not comparisonDict[keyName] == optionDict[keyName]:
-        print "Settings mismatch: %s is '%s', should be '%s'" % (keyName, optionDict[keyName], comparisonDict[keyName])
+        print("Settings mismatch: %s is '%s', should be '%s'" % (keyName, optionDict[keyName], comparisonDict[keyName]))
         sys.exit(0)
 
 sys.exit(1)</string>
@@ -104,9 +104,9 @@ proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (lpadminOut, lpadminErr) = proc.communicate()
 
 if lpadminErr:
-    print "Error: %s" % lpadminErr
+    print("Error: %s" % lpadminErr)
     sys.exit(1)
-print "Results: %s" % lpadminOut    
+print("Results: %s" % lpadminOut)
 sys.exit(0)</string>
 	<key>unattended_install</key>
 	<true/>

--- a/print_generator.py
+++ b/print_generator.py
@@ -1,10 +1,19 @@
 #!/usr/bin/python
-import os
-from plistlib import readPlist, writePlist
-import csv
+from __future__ import absolute_import, print_function
+
 import argparse
-import sys
+import csv
+import os
 import re
+import sys
+
+try:
+    from plistlib import load as load_plist  # Python 3
+    from plistlib import dump as dump_plist
+except ImportError:
+    from plistlib import readPlist as load_plist  # Python 2
+    from plistlib import writePlist as dump_plist
+
 
 def getOptionsString(optionList):
     # optionList should be a list item
@@ -33,7 +42,7 @@ args = parser.parse_args()
 
 pwd = os.path.dirname(os.path.realpath(__file__))
 f = open(os.path.join(pwd, 'AddPrinter-Template.plist'), 'rb')
-templatePlist = readPlist(f)
+templatePlist = load_plist(f)
 f.close()
 
 if args.csv:
@@ -101,7 +110,7 @@ if args.csv:
             # Write out the file
             newFileName = "AddPrinter-" + row[0] + "-" + version + ".pkginfo"
             f = open(newFileName, 'wb')
-            writePlist(newPlist, f)
+            dump_plist(newPlist, f)
             f.close()
 else:
     if not args.printername:
@@ -201,5 +210,5 @@ else:
 
     newFileName = "AddPrinter-" + str(args.printername) + "-%s.pkginfo" % str(version)
     f = open(newFileName, 'wb')
-    writePlist(newPlist, f)
+    dump_plist(newPlist, f)
     f.close()

--- a/print_generator.py
+++ b/print_generator.py
@@ -105,21 +105,21 @@ if args.csv:
             f.close()
 else:
     if not args.printername:
-        print >> sys.stderr, (os.path.basename(sys.argv[0]) + ': error: argument --printername is required')
+        print(os.path.basename(sys.argv[0]) + ': error: argument --printername is required', file=sys.stderr)
         parser.print_usage()
         sys.exit(1)
     if not args.driver:
-        print >> sys.stderr, (os.path.basename(sys.argv[0]) + ': error: argument --driver is required')
+        print(os.path.basename(sys.argv[0]) + ': error: argument --driver is required', file=sys.stderr)
         parser.print_usage()
         sys.exit(1)
     if not args.address:
-        print >> sys.stderr, (os.path.basename(sys.argv[0]) + ': error: argument --address is required')
+        print(os.path.basename(sys.argv[0]) + ': error: argument --address is required', file=sys.stderr)
         parser.print_usage()
         sys.exit(1)
 
     if re.search(r"[\s#/]", args.printername):
         # printernames can't contain spaces, tabs, # or /.  See lpadmin manpage for details.
-        print >> sys.stderr, ("ERROR: Printernames can't contain spaces, tabs, # or /.")
+        print("ERROR: Printernames can't contain spaces, tabs, # or /.", file=sys.stderr)
         sys.exit(1)
 
     if args.desc:


### PR DESCRIPTION
This should enable the script that generates the pkginfo files to run in Python 3. There's still more to be done to enable the template installcheck_script and postinstall_script to be fully Python 3 compatible, but that's less urgent at the moment.