### PR TITLE
Filters out lpadmin will be deprecated messages in 10.15+

### DIFF
--- a/AddPrinter-Template.plist
+++ b/AddPrinter-Template.plist
@@ -104,8 +104,13 @@ proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (lpadminOut, lpadminErr) = proc.communicate()
 
 if lpadminErr:
-    print("Error: %s" % lpadminErr)
-    sys.exit(1)
+        if "Printer drivers are deprecated" in lpadminErr:
+                # work around lpadmin deprecation message
+                print "Install successful - caught deprecation message; preventing exit 1"
+                pass
+        else:
+                print "Error: %s" % lpadminErr
+                sys.exit(1)
 print("Results: %s" % lpadminOut)
 sys.exit(0)</string>
 	<key>unattended_install</key>


### PR DESCRIPTION
This filters out the error on Catalina when a printer is installed with `lpadmin` the system outputs: `Error: lpadmin: Printer drivers are deprecated and will stop working in a future version of CUPS`.